### PR TITLE
add tsc-watch, yarn script for spontaneous declaration updating

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,7 +12,8 @@
     "scripts": {
         "build": "tsc",
         "decl": "tsc --declaration",
-        "build:watch": "tsc --watch"
+        "build:watch": "tsc --watch",
+        "build:watch:decl": "tsc-watch --onSuccess \"yarn decl\""
     },
     "dependencies": {
         "@types/moment-timezone": "^0.5.9",
@@ -28,6 +29,7 @@
         "redux-saga": "^0.16.2",
         "superagent": "^4.0.0-beta.5",
         "ts-jest": "^23.10.4",
+        "tsc-watch": "^1.0.30",
         "tslint": "^5.11.0",
         "tslint-config-prettier": "^1.15.0",
         "tslint-loader": "^3.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,7 +2559,7 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-cross-spawn@5.1.0, cross-spawn@^5.0.1:
+cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
@@ -6982,6 +6982,11 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
+node-cleanup@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
+  integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -9720,6 +9725,11 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
+string-argv@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.1.1.tgz#66bd5ae3823708eaa1916fa5412703150d4ddfaf"
+  integrity sha512-El1Va5ehZ0XTj3Ekw4WFidXvTmt9SrC0+eigdojgtJMVtPkF0qbBe9fyNSl9eQf+kUHnTSQxdQYzuHfZy8V+DQ==
+
 string-length@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
@@ -10252,6 +10262,18 @@ ts-loader@^2.3.7:
     enhanced-resolve "^3.0.0"
     loader-utils "^1.0.2"
     semver "^5.0.1"
+
+tsc-watch@^1.0.30:
+  version "1.0.30"
+  resolved "https://registry.yarnpkg.com/tsc-watch/-/tsc-watch-1.0.30.tgz#dc4f0a974cb4ab622e4317bd3e255bfe9b85eb84"
+  integrity sha512-y4aIyRnzSof+614TIxEU14ZBAH5xbn9rrO4Sb/vXlSeEcNIeYIRbn33gjdtuiwiKKmMw3/hhd7FSm57r0mRa4g==
+  dependencies:
+    chalk "^2.3.0"
+    cross-spawn "^5.1.0"
+    node-cleanup "^2.1.2"
+    ps-tree "^1.1.0"
+    string-argv "^0.1.1"
+    strip-ansi "^4.0.0"
 
 tsconfig-paths-webpack-plugin@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### WHAT

- Add `tsc-watch` in order to automatically update the declaration file on success of each compilation of common, so that the `web` package is in sync with it.